### PR TITLE
Fix: Allow passing in absolute URL for file= parameter

### DIFF
--- a/usd_for_web_demos/test.html
+++ b/usd_for_web_demos/test.html
@@ -19,7 +19,7 @@
     // Load the usd file
     let loadUSDPromise = new Promise( (resolve, reject) => {
       let req = new XMLHttpRequest();
-      req.open("GET", "/" + filename, true);
+      req.open("GET", filename, true);
       req.responseType = "arraybuffer";
 
       req.onload = function (oEvent) {
@@ -39,7 +39,10 @@
     Promise.all([loadUSDPromise, getUsdModule(), initPromise]).then(async ([usdFile, Usd]) => {
       window.Usd = Usd;
 
-      let extension = filename.split('.')[1];
+      // find file extension; strip query parameters and make sure URLs work as well
+      let parts = filename.split('.');
+      let extension = parts[parts.length - 1];
+      extension = extension.split('?')[0];
       let inputFile = 'input.' + extension;
 
       Usd.FS.createDataFile('/', inputFile, new Uint8Array(usdFile), true, true, true);


### PR DESCRIPTION
### Description of Change(s)

This PR adds support for viewing external files with the demo viewer.
It will allow URLs like this to function:
- [https://usd-viewer.glitch.me/?file=https://cdn.glitch.global/bee386a1-31e6-4710-8850-a1d5b7026a09/speeder.usdz?v=1646512428693&cameraX=20&cameraY=10&cameraZ=20](https://usd-viewer.glitch.me/?file=https://cdn.glitch.global/bee386a1-31e6-4710-8850-a1d5b7026a09/speeder.usdz?v=1646512428693&cameraX=20&cameraY=10&cameraZ=20)
- [https://usd-viewer.glitch.me/?file=spherebot2.usdz](https://usd-viewer.glitch.me/?file=spherebot2.usdz)

which makes it useful as a quick way to preview files.

### Fixes Issue(s)
Unable to quickly view other files and test the viewer's capabilities.

<!-- 
Place an X in the box if you have submitted a signed Contributor License Agreement.
A signed CLA must be received before pull requests can be merged.
For instructions, see: http://openusd.org/release/contributing_to_usd.html
-->
- [X] I have submitted a signed Contributor License Agreement
