### PR TITLE
WebGPU Device Initialization

### DIFF
--- a/pxr/imaging/hgiWebGPU/hgi.cpp
+++ b/pxr/imaging/hgiWebGPU/hgi.cpp
@@ -165,7 +165,13 @@ wgpu::Device GetDevice() {
         return "?";
     }
 
+    wgpu::Device s_device = nullptr;
+
     wgpu::Device GetDevice() {
+        if(s_device)
+        {
+            return s_device;
+        }
         instance = std::make_unique<dawn::native::Instance>();
         instance->DiscoverDefaultAdapters();
 
@@ -208,14 +214,14 @@ wgpu::Device GetDevice() {
         descriptor.requiredFeaturesCount = 1;
 
         WGPUDevice cDevice = backendAdapter.CreateDevice(&descriptor);
-        wgpu::Device device = wgpu::Device::Acquire(cDevice);
+        s_device = wgpu::Device::Acquire(cDevice);
         DawnProcTable procs = dawn::native::GetProcs();
 
         dawnProcSetProcs(&procs);
 
         procs.deviceSetUncapturedErrorCallback(cDevice, PrintDeviceError, nullptr);
         procs.deviceSetDeviceLostCallback(cDevice, DeviceLostCallback, nullptr);
-        return device;
+        return s_device;
     }
 #endif  // __EMSCRIPTEN__
 

--- a/pxr/imaging/hgiWebGPU/hgi.cpp
+++ b/pxr/imaging/hgiWebGPU/hgi.cpp
@@ -165,6 +165,7 @@ wgpu::Device GetDevice() {
         return "?";
     }
 
+    // TODO: should make sure we destroy this properly
     wgpu::Device s_device = nullptr;
 
     wgpu::Device GetDevice() {


### PR DESCRIPTION
### Description of Change(s)
I had a stream of DeviceLost errors when building on macOS and running `usdview` with a simple scene using the WebGPU HGI backend.
```
#usda 1.0
def Sphere "sphere" {
    float radius = 0.5
}
```

Seems multiple calls to GetDevice that initialized the WebGPU device were the culprit. If I stored the first device created device and returned that (if it existed) then things seemed to work.

Awesome work getting this out there btw, thanks for making it public!